### PR TITLE
Fixing the typo "convertor" -> "converter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ java -cp YWWTools.jar:deps.jar yang.weiwei.Tools --tool tokenizer --corpus <corp
 ### <h3 id="corpus_converter_cmd">Corpus Converter</h3>
 
 ```
-java -cp YWWTools.jar:deps.jar yang.weiwei.Tools --tool corpus-convertor {--get-vocab|--to-index|--to-word} --word-corpus <word-corpus-file> --index-corpus <index-corpus-file> --vocab <vocab-file>
+java -cp YWWTools.jar:deps.jar yang.weiwei.Tools --tool corpus-converter {--get-vocab|--to-index|--to-word} --word-corpus <word-corpus-file> --index-corpus <index-corpus-file> --vocab <vocab-file>
 ```
 
 - New implementation


### PR DESCRIPTION
Since this typo caused an error, and this script is the first step trying your code, I thought it was important to fix it even if it is one line.

TEST:

    $ java -cp YWWTools.jar:deps.jar yang.weiwei.Tools --tool corpus-converter --get-vocab --word-corpus /Users/Fujinuma/work/crisisNLP_LRL/data/lorelei/uzbek/ltf/uzbek_lorelei_tokenized_text.txt --vocab uzbek_lorelei_tokenized_text.txt.vocab